### PR TITLE
feat: Add slash to alias and aliasPath

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -47,8 +47,10 @@ async function getAbsPath(
     return path.resolve(dirname, file);
   }
 
-  for (const [_alias, aliasPath] of Object.entries(aliases)) {
-    const alias = _alias.endsWith("/") ? _alias : `${_alias}/`;
+  for (const [_alias, _aliasPath] of Object.entries(aliases)) {
+    const addSlash = (str: string) => (str.endsWith("/") ? str : `${str}/`);
+    const alias = addSlash(_alias);
+    const aliasPath = addSlash(_aliasPath);
     if (file.startsWith(alias)) {
       const s = new MagicString(file);
       s.overwrite(0, alias.length, aliasPath);


### PR DESCRIPTION
This commit modifies the loop over aliases to ensure that both the alias
and the aliasPath have a trailing slash. This is done by introducing a
new function, addSlash, which appends a slash to a string if it does not
already end with one. This change ensures consistent formatting of
aliases and their paths.
